### PR TITLE
Revert "Update Helm release prometheus-operator-crds to v5"

### DIFF
--- a/crds/base/prometheus-operator.yaml
+++ b/crds/base/prometheus-operator.yaml
@@ -12,5 +12,5 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      version: 5.0.0
+      version: 4.0.2
   interval: 1m0s


### PR DESCRIPTION
Reverts damoun/fleet-infra#118

Upgrading prometheus-operator-crds require extra step