### PR TITLE
Revert "Update Helm release kube-prometheus-stack to v47.3.0"

### DIFF
--- a/apps/base/monitoring/kube-prometheus-stack/helmrelease.yaml
+++ b/apps/base/monitoring/kube-prometheus-stack/helmrelease.yaml
@@ -14,5 +14,5 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: prometheus-community
-      version: 47.3.0
+      version: 47.2.0
   interval: 1m0s


### PR DESCRIPTION
Reverts damoun/fleet-infra#143

Grafana CrashLoop so let's rollback